### PR TITLE
🚑 Fixed-pr-to-main

### DIFF
--- a/.github/workflows/prToMainHandler.yml
+++ b/.github/workflows/prToMainHandler.yml
@@ -9,9 +9,9 @@ on:
       development_pr_creator:
         required: true
         type: string
+    secrets:
       personal_access_token:
         required: true
-        type: string
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
         if: steps.parent_pr_number.outcome == 'failure'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ inputs.personal_access_token }}
+          token: ${{ secrets.personal_access_token }}
           base: main
           branch: dev-${{ steps.last_commit.outputs.sha }}
           title: "🔀 [Prod] ${{ steps.pr_details.outputs.title }} - #${{ inputs.development_pr_number }} by @${{ inputs.development_pr_creator }}"

--- a/.github/workflows/prToMainHandler.yml
+++ b/.github/workflows/prToMainHandler.yml
@@ -90,7 +90,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.personal_access_token }}
-          base: main
+          base: ${{ github.head_ref }}
           branch: dev-${{ steps.last_commit.outputs.sha }}
           title: "🔀 [Prod] ${{ steps.pr_details.outputs.title }} - #${{ inputs.development_pr_number }} by @${{ inputs.development_pr_creator }}"
           body: |

--- a/.github/workflows/prToMainHandler.yml
+++ b/.github/workflows/prToMainHandler.yml
@@ -77,20 +77,17 @@ jobs:
           git commit --no-edit
 
       - name: Push branch
+        if: steps.parent_pr_number.outcome != 'failure'
         run: |
-          if [ "${{ steps.parent_pr_number.outcome }}" == "failure" ]; then
-            git push origin dev-${{ steps.last_commit.outputs.sha }}
-          else
-            parent_branch=$(gh pr view ${{ steps.parent_pr_number.outputs.parent_pr }} --json headRefName --jq '.headRefName')
-            git push origin HEAD:$parent_branch
-          fi
+          parent_branch=$(gh pr view ${{ steps.parent_pr_number.outputs.parent_pr }} --json headRefName --jq '.headRefName')
+          git push origin HEAD:$parent_branch
 
       - name: Create pull request
         if: steps.parent_pr_number.outcome == 'failure'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.personal_access_token }}
-          base: ${{ github.head_ref }}
+          base: main
           branch: dev-${{ steps.last_commit.outputs.sha }}
           title: "🔀 [Prod] ${{ steps.pr_details.outputs.title }} - #${{ inputs.development_pr_number }} by @${{ inputs.development_pr_creator }}"
           body: |


### PR DESCRIPTION
Se quita el push a main en el step previo a crear el PR porque el action de crear el PR ya hace eso. Se arregla el uso de secrets tambien