### PR TITLE
prevents unnecessary commits when no changes are present after resolving conflicts

### DIFF
--- a/.github/workflows/prToMainHandler.yml
+++ b/.github/workflows/prToMainHandler.yml
@@ -77,8 +77,12 @@ jobs:
       - name: Commit conflicts if cherry pick fails
         if: ${{ steps.cherry_pick.outcome == 'failure' }}
         run: |
-          git add .
-          git commit --no-edit
+          if git status --porcelain | grep '^[MADRCU]'; then
+            git add .
+            git commit --no-edit
+          else
+            echo "No changes to commit after resolving conflicts"
+          fi
 
       - name: Push branch
         run: |

--- a/.github/workflows/prToMainHandler.yml
+++ b/.github/workflows/prToMainHandler.yml
@@ -93,11 +93,23 @@ jobs:
             git push origin HEAD:$parent_branch
           fi
 
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git fetch origin main
+          CHANGES=$(git rev-list --count main..HEAD)
+          echo "has_changes=$CHANGES" >> $GITHUB_OUTPUT
+
       - name: Create pull request
-        if: steps.parent_pr_number.outcome == 'failure'
+        if: steps.parent_pr_number.outcome == 'failure' && steps.check_changes.outputs.has_changes != '0'
         run: |
           if [ "${{ steps.cherry_pick.outcome }}" == "failure" ]; then
             gh pr create -B main -H dev-${{ steps.last_commit.outputs.sha }} --title '🔀 [Prod] ${{ steps.pr_details.outputs.title }} - #${{ inputs.development_pr_number }} by @${{ inputs.development_pr_creator }}' --body ':warning: This PR had conflicts with main. Make sure the changes are correct before proceeding. <br> This PR includes changes from the last commit ${{ steps.last_commit.outputs.sha }}, PR \#${{ inputs.development_pr_number }} in ${{ inputs.reference_branch }}.' --assignee ${{ inputs.development_pr_creator }} --draft
           else
             gh pr create -B main -H dev-${{ steps.last_commit.outputs.sha }} --title '🔀 [Prod] ${{ steps.pr_details.outputs.title }} - #${{ inputs.development_pr_number }} by @${{ inputs.development_pr_creator }}' --body 'This PR includes changes from the last commit ${{ steps.last_commit.outputs.sha }}, PR \#${{ inputs.development_pr_number }} in ${{ inputs.reference_branch }}.' --assignee ${{ inputs.development_pr_creator }} --draft
           fi
+
+      - name: Show no changes message
+        if: steps.check_changes.outputs.has_changes == '0'
+        run: |
+          echo "No hay cambios para crear un Pull Request. Los cambios ya están presentes en la rama main."

--- a/.github/workflows/prToMainHandler.yml
+++ b/.github/workflows/prToMainHandler.yml
@@ -96,8 +96,10 @@ jobs:
       - name: Check for changes
         id: check_changes
         run: |
-          git fetch origin main
-          CHANGES=$(git rev-list --count main..HEAD)
+          git fetch origin main:main
+          git rev-parse --verify HEAD
+          git rev-parse --verify main
+          CHANGES=$(git rev-list --count main..HEAD || echo "0")
           echo "has_changes=$CHANGES" >> $GITHUB_OUTPUT
 
       - name: Create pull request

--- a/.github/workflows/prToMasterHandler.yml
+++ b/.github/workflows/prToMasterHandler.yml
@@ -96,8 +96,10 @@ jobs:
       - name: Check for changes
         id: check_changes
         run: |
-          git fetch origin master
-          CHANGES=$(git rev-list --count master..HEAD)
+          git fetch origin master:master
+          git rev-parse --verify HEAD
+          git rev-parse --verify master
+          CHANGES=$(git rev-list --count master..HEAD || echo "0")
           echo "has_changes=$CHANGES" >> $GITHUB_OUTPUT
 
       - name: Create pull request

--- a/.github/workflows/prToMasterHandler.yml
+++ b/.github/workflows/prToMasterHandler.yml
@@ -77,8 +77,12 @@ jobs:
       - name: Commit conflicts if cherry pick fails
         if: ${{ steps.cherry_pick.outcome == 'failure' }}
         run: |
-          git add .
-          git commit --no-edit
+          if git status --porcelain | grep '^[MADRCU]'; then
+            git add .
+            git commit --no-edit
+          else
+            echo "No changes to commit after resolving conflicts"
+          fi
 
       - name: Push branch
         run: |

--- a/.github/workflows/prToMasterHandler.yml
+++ b/.github/workflows/prToMasterHandler.yml
@@ -93,11 +93,23 @@ jobs:
             git push origin HEAD:$parent_branch
           fi
 
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git fetch origin master
+          CHANGES=$(git rev-list --count master..HEAD)
+          echo "has_changes=$CHANGES" >> $GITHUB_OUTPUT
+
       - name: Create pull request
-        if: steps.parent_pr_number.outcome == 'failure'
+        if: steps.parent_pr_number.outcome == 'failure' && steps.check_changes.outputs.has_changes != '0'
         run: |
           if [ "${{ steps.cherry_pick.outcome }}" == "failure" ]; then
             gh pr create -B master -H dev-${{ steps.last_commit.outputs.sha }} --title '🔀 [Prod] ${{ steps.pr_details.outputs.title }} - #${{ inputs.development_pr_number }} by @${{ inputs.development_pr_creator }}' --body ':warning: This PR had conflicts with master. Make sure the changes are correct before proceeding. <br> This PR includes changes from the last commit ${{ steps.last_commit.outputs.sha }}, PR \#${{ inputs.development_pr_number }} in ${{ inputs.reference_branch }}.' --assignee ${{ inputs.development_pr_creator }} --draft
           else
             gh pr create -B master -H dev-${{ steps.last_commit.outputs.sha }} --title '🔀 [Prod] ${{ steps.pr_details.outputs.title }} - #${{ inputs.development_pr_number }} by @${{ inputs.development_pr_creator }}' --body 'This PR includes changes from the last commit ${{ steps.last_commit.outputs.sha }}, PR \#${{ inputs.development_pr_number }} in ${{ inputs.reference_branch }}.' --assignee ${{ inputs.development_pr_creator }} --draft
           fi
+
+      - name: Show no changes message
+        if: steps.check_changes.outputs.has_changes == '0'
+        run: |
+          echo "No hay cambios para crear un Pull Request. Los cambios ya están presentes en la rama master."


### PR DESCRIPTION
El comando `git status --porcelain | grep '^[MADRCU]'` verifica el estado del repositorio y busca líneas que empiecen con cualquiera de esos caracteres que indican cambios (Modified, Added, Deleted, Renamed, Copied, Updated)

Se añadió un nuevo paso para evaluar si existen cambios y se agregó una condición al crear los pull request para evaluar si es que existen cambios desde el último commit