### PR TITLE
fix: remove || true from grep to preserve step failure behavior

### DIFF
--- a/.github/workflows/prToMainHandler.yml
+++ b/.github/workflows/prToMainHandler.yml
@@ -97,7 +97,10 @@ jobs:
         env:
           PR_COMMENTS: ${{ steps.pr_details.outputs.comments }}
         run: |
-          parent_pr=$(echo "$PR_COMMENTS" | grep -oP '/parent #\K\d+' || true)
+          # grep will exit 1 if no match found, which is expected behavior
+          # continue-on-error: true allows workflow to continue
+          # outcome will be 'failure' if no /parent # comment exists
+          parent_pr=$(echo "$PR_COMMENTS" | grep -oP '/parent #\K\d+')
           echo "parent_pr=$parent_pr" >> $GITHUB_OUTPUT
         continue-on-error: true
 


### PR DESCRIPTION
## Cuál es el objetivo de este PR

Corregir el bug introducido en PR #12 donde el workflow no creaba PRs a main.

**Problema:** Se agregó `|| true` al comando grep, lo que causaba que el step siempre terminara con `outcome: success` incluso cuando no encontraba un comentario `/parent #`. Esto hacía que el workflow intentara hacer checkout de un "parent PR branch" inexistente en lugar de checkout desde main.

**Solución:** Remover `|| true` para que grep falle naturalmente cuando no encuentra match. El `continue-on-error: true` permite que el workflow continúe, pero el `outcome` será `failure`, que es el comportamiento esperado.

## Testing & QA

1. Mergear este PR
2. Re-ejecutar el workflow en crm-backend para PR #3033
3. Verificar que el PR a main se crea correctamente

## Tickets relacionados

- Error en workflow run: https://github.com/Keiron-HealthTech/crm-backend/actions/runs/21723594767

## Deploys, dependencias externas, etc.

No requiere cambios adicionales.