### PR TITLE
feat(codex): default review model to gpt-5.2-codex

### DIFF
--- a/.github/workflows/codexPrReview.yml
+++ b/.github/workflows/codexPrReview.yml
@@ -27,10 +27,10 @@ on:
         default: ""
       # Optional Codex model override (passes through to openai/codex-action@v1).
       model:
-        description: "Codex model identifier (e.g., 'gpt-5'). Empty = action default."
+        description: "Codex model identifier (e.g., 'gpt-5'). Defaults to 'gpt-5.2-codex'."
         required: false
         type: string
-        default: ""
+        default: "gpt-5.2-codex"
       # Caller toggle: post Codex output as a PR comment (default true).
       # Set false to dry-run the workflow without making any PR comments.
       comment_on_pr:


### PR DESCRIPTION
## Summary

Set the default Codex model for the reusable **Codex PR Review** workflow (`.github/workflows/codexPrReview.yml`) to `gpt-5.2-codex`.

Previously the `model` input defaulted to `""`, which deferred to `openai/codex-action@v1`'s built-in default. Now the workflow pins a concrete model so review behavior is predictable and explicitly version-controlled here.

## Changes

- `model` input `default: ""` → `default: "gpt-5.2-codex"`
- Updated the input description accordingly

## Compatibility

- **Backward compatible**: callers that pass an explicit `model:` still override the default (forwarded verbatim at the `Run Codex` step).
- Only callers that previously omitted `model` are affected — they now get `gpt-5.2-codex` instead of the action's internal default.
- Trade-off: future action-default model bumps no longer auto-apply; the model version is now controlled in this repo.

## Verification

- YAML validated with `yaml.safe_load` ✅
- No README/docs referenced the old default — none needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)